### PR TITLE
Fix Czech capitalization of months

### DIFF
--- a/ez-today.typ
+++ b/ez-today.typ
@@ -10,7 +10,7 @@
   } else if lang == "it" {
     months = ("Gennaio", "Febbraio", "Marzo", "Aprile", "Maggio", "Giugno", "Luglio", "Agosto", "Settembre", "Ottobre", "Novembre", "Dicembre")
   } else if lang == "cs" {
-    months = ("Ledna", "Února", "Března", "Dubna", "Května", "Června", "Července", "Srpna", "Září", "Října", "Listopadu", "Prosince")
+    months = ("ledna", "února", "března", "dubna", "května", "června", "července", "srpna", "září", "října", "listopadu", "prosince")
   } else if lang == "pt" {
     months = ("Janeiro", "Fevereiro", "Março", "Abril", "Maio", "Junho", "Julho", "Agosto", "Setembro", "Outubro", "Novembro", "Dezembro")
   } else if lang == "sk" {


### PR DESCRIPTION
In Czech when writing dates, we use the name of the month starting with lowercase. [Source (Czech)](https://prirucka.ujc.cas.cz/?id=810)

That is, March 1st 20224 is 1. března 2024.