### PR TITLE
Styling, and Swedish language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ You can choose one of the included languages with the `lang` argument:
 #ez-today.today(lang: "pt")   // 11. Outubro 2024
 #ez-today.today(lang: "sk")   // 11. Októbra 2024
 #ez-today.today(lang: "pl")   // 11. Października 2024
-#ez-today.today(lang: "se")   // 11. januari 2024
+#ez-today.today(lang: "se")   // 11. oktober 2024
 ```
 
 You can also change the format of the output with the `format` argument. Pass any string you want here, but know that the following characters will be replaced with the following:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Simply displays the current date with easy to use customization.
 
 ## Included languages
 
-German, English, French, Italian, Czech, Portuguese, Slovakian and Polish months can be used out of the box. If you want to use a language that is not included, you can easily add it yourself. This is shown in the customization section below.
+German, English, French, Italian, Czech, Portuguese, Slovakian, Swedish and Polish months can be used out of the box. If you want to use a language that is not included, you can easily add it yourself. This is shown in the customization section below.
 
 ## Usage
 
@@ -55,6 +55,7 @@ You can choose one of the included languages with the `lang` argument:
 #ez-today.today(lang: "pt")   // 11. Outubro 2024
 #ez-today.today(lang: "sk")   // 11. Októbra 2024
 #ez-today.today(lang: "pl")   // 11. Października 2024
+#ez-today.today(lang: "se")   // 11. januari 2024
 ```
 
 You can also change the format of the output with the `format` argument. Pass any string you want here, but know that the following characters will be replaced with the following:

--- a/examples/example.typ
+++ b/examples/example.typ
@@ -16,3 +16,6 @@
 
 // Use automatic English ordinal suffix (st, nd, rd, th)
 #ez-today.today(format: "ds M")
+
+// Specify a language
+#ez-today.today(lang: "se", format: "d M Y")

--- a/ez-today.typ
+++ b/ez-today.typ
@@ -85,7 +85,7 @@
     } else if f == "S" {
       [#get-en-suffix(day-int)]
     } else if f == "s" {
-      [$zws^#get-en-suffix(day-int)$]
+      [#super[#get-en-suffix(day-int)]]
     }
     else {
       f

--- a/ez-today.typ
+++ b/ez-today.typ
@@ -19,6 +19,8 @@
     months = ("Januára", "Februára", "Marca", "Apríla", "Mája", "Júna", "Júla", "Augusta", "Septembera", "Októbra", "Novembra", "Decembra")
   } else if lang == "pl" {
     months = ("Stycznia", "Lutego", "Marca", "Kwietnia", "Maja", "Czerwca", "Lipca", "Sierpnia", "Września", "Października", "Listopada", "Grudnia")
+  } else if lang == "se" {
+    months = ("januari", "februari", "mars", "april", "maj", "juni", "juli", "augusti", "september", "oktober", "november", "december")
   } else {
     return ""
   }


### PR DESCRIPTION
Hi there!
I propose two changes:
- Making superscripts of English ordinal numbers appear in the same font as the month.
- Adding Swedish language support